### PR TITLE
contrib: +bdube, refresh license go-hep => astrogo; year

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,4 +1,4 @@
-# This is the official list of go-hep authors for copyright purposes.
+# This is the official list of astrogo authors for copyright purposes.
 # This file is distinct from the CONTRIBUTORS files.
 # See the latter for an explanation.
 
@@ -12,3 +12,4 @@ Sebastien Binet <binet@cern.ch>
 Thomas Bellembois <thomas.bellembois@gmail.com>
 Fabio Hernandez <fabio@in2p3.fr>
 Rick Bassham <brodrick.bassham@gmail.com>
+Brandon Dube <brandon.dube@jpl.nasa.gov>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,5 +1,5 @@
 # This is the official list of people who can contribute
-# (and typically have contributed) code to the go-hep
+# (and typically have contributed) code to the astrogo
 # repository.
 #
 # The AUTHORS file lists the copyright holders; this file
@@ -19,3 +19,4 @@ Sebastien Binet <binet@cern.ch>
 Thomas Bellembois <thomas.bellembois@gmail.com>
 Fabio Hernandez <fabio@in2p3.fr>
 Rick Bassham <brodrick.bassham@gmail.com>
+Brandon Dube <brandon.dube@jpl.nasa.gov>

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright ©2012-2020 The astrogo Authors. All rights reserved.
+Copyright ©2012 The astrogo Authors. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright ©2012 The go-hep Authors. All rights reserved.
+Copyright ©2012-2020 The astrogo Authors. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
@@ -7,7 +7,7 @@ modification, are permitted provided that the following conditions are met:
     * Redistributions in binary form must reproduce the above copyright
       notice, this list of conditions and the following disclaimer in the
       documentation and/or other materials provided with the distribution.
-    * Neither the name of the go-hep project nor the names of its authors and
+    * Neither the name of the astrogo project nor the names of its authors and
       contributors may be used to endorse or promote products derived from this
       software without specific prior written permission.
 


### PR DESCRIPTION
title is self explanatory.

Other changes:

- go-hep => astrogo (matches org name)

- (C) 2012 => 2012-2020